### PR TITLE
Add support for custom CI implementations

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,17 @@ if (process.env.TRAVIS) {
   commit_message = '' // wercker does not expose commit message
   branch = process.env.WERCKER_GIT_BRANCH
   ci = 'wercker'
+} else if (process.env.CI) {
+  // Generic variables for docker images, custom CI builds, etc.
+  
+  repo =
+    process.env.CI_REPO_OWNER + '/' + process.env.CI_REPO_NAME
+
+  sha = process.env.CI_COMMIT_SHA
+  event = process.env.CI_EVENT || 'push'
+  commit_message = process.env.CI_COMMIT_MESSAGE
+  branch = process.env.CI_BRANCH
+  ci = 'custom'
 }
 
 module.exports = { repo, sha, event, commit_message, branch, ci }


### PR DESCRIPTION
`ci-env` supports travis, circle, wercker and [drone](https://github.com/siddharthkp/ci-env/pull/3) right now.

But, there are self hosted or containerised environments where these will not be used.

We can add support for those by supporting generic environment variables.