### PR TITLE
Add support for Codeship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# IDEs by JetBrains
+.idea

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 &nbsp;
 
-Supports travisCI and circleCI.
+Supports travisCI, circleCI and Codeship.
 
 &nbsp;
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,17 @@ if (process.env.TRAVIS) {
   commit_message = '' // drone does not expose commit message
   branch = process.env.DRONE_BRANCH || process.env.CI_BRANCH
   ci = 'drone'
+} else if (process.env.CI_NAME === 'codeship') {
+  // Reference: https://documentation.codeship.com/pro/builds-and-configuration/environment-variables/#default-environment-variables
+
+  repo = process.env.CI_REPO_NAME
+  sha = process.env.CI_COMMIT_ID
+  commit_message = process.env.CI_COMMIT_MESSAGE || process.env.CI_MESSAGE
+  branch = process.env.CI_BRANCH
+
+  // CI_PULL_REQUEST is always false
+  event = 'push'
+  ci = 'codeship'
 } else if (process.env.CI) {
   // Generic variables for docker images, custom CI builds, etc.
   


### PR DESCRIPTION
Resolves #11

This pull request adds support for Codeship, which turned out to be a lot simpler than I first expected. Codeship does some pretty weird stuff with environment variables, but the ones needed are (almost) all readily available! :-)

Codeship has no config file, so I didn't add anything to `test.js`. I double-checked on our own Codeship that the environment variables used are populated correctly. Strange enough, `CI_COMMIT_MESSAGE` was empty for me on a regular commit, but `CI_MESSAGE` did contain the commit message. I left `CI_COMMIT_MESSAGE` in the code in case Codeship ever decides to give it a proper value, but I can remove it if wanted.

I tested this using the following script on our Codeship, note that most of it is redacted or even not included due to it being irrelevant:
```bash
#!/usr/bin/env bash

set -e;

export CI=$CI_NAME;
export CI_COMMIT_SHA=$CI_COMMIT_ID;
export CI_COMMIT_MESSAGE=$CI_MESSAGE;
export CI_EVENT="push";
export CI_REPO_OWNER="<redacted>";
export CI_REPO_NAME="<redacted>";

function status {
    cyan="\033[0;36m";
    nc="\033[0m";
    echo -e "${cyan}$1${nc}";
}

status "Start compiling bundles...";
yarn build;
status "Finished compiling bundles.";

status "Starting bundlesize tests...";
yarn run bundlesize;
status "Finished bundlesize tests.";
```

<img width="758" alt="screen shot 2017-11-07 at 23 16 05" src="https://user-images.githubusercontent.com/1649903/32520833-b2f99b12-c411-11e7-9c3e-b1f46d12a62d.png">
<img width="776" alt="screen shot 2017-11-07 at 23 18 18" src="https://user-images.githubusercontent.com/1649903/32520947-0e93dbc2-c412-11e7-91f0-66d968efae07.png">
