### PR TITLE
Change buildUrl for jobUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,4 +79,4 @@ if (process.env.TRAVIS) {
   ci = 'custom'
 }
 
-module.exports = { repo, sha, event, commit_message, branch, pull_request_number, ci, buildUrl }
+module.exports = { repo, sha, event, commit_message, branch, pull_request_number, ci, jobUrl }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 let drone = require('./utils/drone')
-let repo, sha, event, commit_message, pull_request_number, branch, ci, buildUrl
+let repo, sha, event, commit_message, pull_request_number, branch, ci, jobUrl
 
 if (process.env.TRAVIS) {
   // Reference: https://docs.travis-ci.com/user/environment-variables
@@ -9,7 +9,7 @@ if (process.env.TRAVIS) {
   event = process.env.TRAVIS_EVENT_TYPE
   commit_message = process.env.TRAVIS_COMMIT_MESSAGE
   pull_request_number = process.env.TRAVIS_PULL_REQUEST
-  buildUrl = `https://travis-ci.org/${repo}/builds/${process.env.TRAVIS_JOB_ID}`
+  jobUrl = `https://travis-ci.org/${repo}/jobs/${process.env.TRAVIS_JOB_ID}`
 
   branch =
     process.env.TRAVIS_EVENT_TYPE === 'push'

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 
-const { buildUrl, repo, sha, event, commit_message, pull_request_number, branch, ci } = require('./index')
+const { jobUrl, repo, sha, event, commit_message, pull_request_number, branch, ci } = require('./index')
 
 if (ci) {
   console.log('values: ', { repo, sha, event, commit_message, pull_request_number, branch, ci })
@@ -50,9 +50,9 @@ if (ci) {
     t.is(pull_request_number, real_pull_request_number)
   })
 
-  test('buildUrl is set', t => {
-    let real_buildUrl
-    if (process.env.TRAVIS) real_buildUrl = `https://travis-ci.org/${repo}/builds/${process.env.TRAVIS_JOB_ID}`
+  test('jobUrl is set', t => {
+    let real_jobUrl
+    if (process.env.TRAVIS) real_jobUrl = `https://travis-ci.org/${repo}/jobs/${process.env.TRAVIS_JOB_ID}`
     t.is(buildUrl, real_buildUrl)
   })
 


### PR DESCRIPTION
This change is promoted because currently is not possible get the build URL

Related: https://github.com/travis-ci/travis-ci/issues/8935

This means that the current output provided by `buildUrl` is not valid.

However, it's possible to get the job URL (that was the real intention of shipping this variable in the module)

The difference is that a build can contain more than one job.