### PR TITLE
Set event to `pull_request` on CircleCI pull requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ if (process.env.TRAVIS) {
   commit_message = '' // circle does not expose commit message
   if (process.env.CI_PULL_REQUEST) {
     pull_request_number = process.env.CI_PULL_REQUEST.split('/').pop() // take number from returns url
+    event = 'pull_request'
   } else pull_request_number = ''
   branch = process.env.CIRCLE_BRANCH
   ci = 'circle'


### PR DESCRIPTION
Hey @siddharthkp 👋 

We're in the process of migrating to CircleCI and found out that we cannot know when the build is coming from a PR to deploy our site to Now using `now-cd`.

Traced out the issue to here and this seems to be a proper fix.

Thank you 😄 

PS: we'll need a new release of `now-cd` after merging this 