### PR TITLE
fix branch returning incorrect value for GitHub Actions

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ if (process.env.TRAVIS) {
   buildUrl=process.env.CI_BUILD_URL
 
   ci = 'codeship'
-} else if (process.env.GITHUB_ACTIONS) {
+} else if (process.env.GITHUB_ACTION) {
   // GitHub Actions
   // Reference: https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/
 

--- a/index.js
+++ b/index.js
@@ -65,11 +65,11 @@ if (process.env.TRAVIS) {
 
   event = 'push'
   pull_request_number = process.env.CI_PR_NUMBER
-  sha=process.env.CI_COMMIT_ID, 
+  sha=process.env.CI_COMMIT_ID,
   buildUrl=process.env.CI_BUILD_URL
-  
+
   ci = 'codeship'
-} else if (process.env.GITHUB_ACTION) {
+} else if (process.env.GITHUB_ACTIONS) {
   // GitHub Actions
   // Reference: https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/
 
@@ -79,7 +79,8 @@ if (process.env.TRAVIS) {
   event = process.env.GITHUB_EVENT_NAME
   commit_message = ''
   pull_request_number = ''
-  branch = process.env.GITHUB_REF
+  // GITHUB_HEAD_REF for pull requests. For commits, GITHUB_REF is of the form refs/heads/master, for example
+  branch = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF && process.env.GITHUB_REF.split('/')[2]
   ci = 'github_actions'
 } else if (process.env.NETLIFY) {
   // Reference: https://www.netlify.com/docs/continuous-deployment/#environment-variables


### PR DESCRIPTION
Fixes https://github.com/siddharthkp/ci-env/issues/28

`process.env.GITHUB_ACTIONS` is set to `true`, which is the true check for GitHub actions environment.

![image](https://user-images.githubusercontent.com/7688231/67164979-906d2d80-f39d-11e9-940c-db215fab069a.png)

For commits, I found no straightforward way to get the branch name.