### PR TITLE
Read domain and prefix ENVs for GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install ci-env
 #### Usage
 
 ```js
-const { repo, sha, event, commit_message, pull_request_number, branch, ci } = require('ci-env')
+const { repo, sha, event, commit_message, pull_request_number, branch, ci, domain, prefix } = require('ci-env')
 ```
 
 &nbsp;
@@ -37,4 +37,4 @@ const { repo, sha, event, commit_message, pull_request_number, branch, ci } = re
 
 #### License
 
-MIT © siddharthkp
+MIT © [siddharthkp](https://github.com/siddharthkp)

--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ let repo,
   branch,
   ci,
   jobUrl,
-  buildUrl;
+  buildUrl,
+  domain,
+  prefix;
 
 if (process.env.TRAVIS) {
   // Reference: https://docs.travis-ci.com/user/environment-variables
@@ -175,6 +177,8 @@ if (process.env.TRAVIS) {
   pull_request_target_branch = process.env.CI_TARGET_BRANCH;
   branch = process.env.CI_BRANCH;
   ci = process.env.CI;
+  domain = process.env.CI_REPO_DOMAIN;
+  prefix = process.env.CI_REPO_PREFIX;
 }
 
 module.exports = {
@@ -189,4 +193,6 @@ module.exports = {
   platform,
   jobUrl,
   buildUrl,
+  domain,
+  prefix
 };

--- a/test.js
+++ b/test.js
@@ -10,7 +10,9 @@ const {
   pull_request_number,
   branch,
   ci,
-  platform
+  platform,
+  domain,
+  prefix,
 } = require("./index");
 
 if (ci) {
@@ -21,7 +23,10 @@ if (ci) {
     commit_message,
     pull_request_number,
     branch,
-    ci
+    ci,
+    platform,
+    domain,
+    prefix
   });
 
   test("ci is correctly set", t => {

--- a/test.js
+++ b/test.js
@@ -132,6 +132,18 @@ if (ci) {
       t.is(branch, real_branch);
     }
   });
+
+  test("domain defaults to undefined", t => {
+    const real_domain = domain; //gitlab
+
+    t.is(real_domain, undefined);
+  });
+
+  test("prefix defaults to undefined", t => {
+    const real_prefix = prefix; //gitlab
+
+    t.is(real_prefix, undefined);
+  });
 } else {
   test.skip("These tests can only run in CI environments", t => t.pass());
 }

--- a/test.js
+++ b/test.js
@@ -134,13 +134,13 @@ if (ci) {
   });
 
   test("domain defaults to undefined", t => {
-    const real_domain = domain; //gitlab
+    const real_domain = domain;
 
     t.is(real_domain, undefined);
   });
 
   test("prefix defaults to undefined", t => {
-    const real_prefix = prefix; //gitlab
+    const real_prefix = prefix;
 
     t.is(real_prefix, undefined);
   });


### PR DESCRIPTION
Expose `domain` and `prefix` variables so they can be read for repositories that are not hosted on GitHub, like GitHub Enterprise.

Fixes #40.