### PR TITLE
handle .com and .org travis urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ let repo,
   buildUrl;
 
 if (process.env.TRAVIS) {
+  const isDotCom = process.env.TRAVIS_BUILD_WEB_URL.includes('.com')
+  const suffix = isDotCom ? '.com' : '.org' 
+  
   // Reference: https://docs.travis-ci.com/user/environment-variables
 
   repo = process.env.TRAVIS_REPO_SLUG;
@@ -22,8 +25,8 @@ if (process.env.TRAVIS) {
   event = process.env.TRAVIS_EVENT_TYPE;
   commit_message = process.env.TRAVIS_COMMIT_MESSAGE;
   pull_request_number = process.env.TRAVIS_PULL_REQUEST;
-  jobUrl = `https://travis-ci.org/${repo}/jobs/${process.env.TRAVIS_JOB_ID}`;
-  buildUrl = `https://travis-ci.org/${repo}/builds/${process.env.TRAVIS_JOB_ID}`;
+  jobUrl = `https://travis-ci.${suffix}/${repo}/jobs/${process.env.TRAVIS_JOB_ID}`;
+  buildUrl = `https://travis-ci.${suffix}/${repo}/builds/${process.env.TRAVIS_JOB_ID}`;
 
   branch =
     process.env.TRAVIS_EVENT_TYPE === 'push'


### PR DESCRIPTION
Travis is totally broken since they have two different URLs for jobs.

I can see at https://docs.travis-ci.com/user/environment-variables/ that `TRAVIS_JOB_WEB_URL` and `TRAVIS_BUILD_WEB_URL` can be used for detecting if the job us running under `travis-ci.com` or `travis-ci.org` and create the `jobUrl` accordingly.