### PR TITLE
Fix: Allow branch names with slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,8 @@ if (process.env.TRAVIS) {
   // for pull_request event, GITHUB_REF is of the form refs/pull/<pull_request_number>/merge
   // for push event, GITHUB_REF is of the form refs/heads/<branch>
 
-  const pull_request_numberORbranch = process.env.GITHUB_REF.split('/')[2];
+  const pull_request_numberORbranch = 
+    event === 'pull_request' ? process.env.GITHUB_REF.split('/')[2] : process.env.GITHUB_REF.split('/').slice(2).join('/');
 
   repo = process.env.GITHUB_REPOSITORY;
   sha = process.env.GITHUB_SHA;


### PR DESCRIPTION
If someone names a branch something like `bug/foo-bar`, then both bundlesize and bundlewatch stop working. This seems like a pretty common pattern (esp for teams who use `username/my-new-feature`), and is likely creating quite a bit of turmoil amongst users atm ❤️ 

Thanks so much for this tool!

cc: @iamogbz